### PR TITLE
Fix timestamp logging if LC_ALL or LC_TIME is set

### DIFF
--- a/scripts/dmg-scripts/uninstall-complete.sh
+++ b/scripts/dmg-scripts/uninstall-complete.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set +e
-date -j -f "%a %b %d %T %Z %Y" "`date`" "+%s" >> /tmp/o3x.log
+date '+%s' >> /tmp/o3x.log
 echo $0 >> /tmp/o3x.log
 pkgutil --pkgs | grep net.lundman.openzfs |\
 while read apkg

--- a/scripts/pkg-scripts/postinstall_actions/kextspost
+++ b/scripts/pkg-scripts/postinstall_actions/kextspost
@@ -1,5 +1,5 @@
 #!/bin/sh
-date -j -f "%a %b %d %T %Z %Y" "`date`" "+%s" >> /tmp/o3x.log
+date '+%s' >> /tmp/o3x.log
 echo $0 >> /tmp/o3x.log
 
 if [ "$(uname -r | awk -F '.' '{print $1;}')" -lt 13 ] ; then

--- a/scripts/pkg-scripts/postinstall_actions/loadplists
+++ b/scripts/pkg-scripts/postinstall_actions/loadplists
@@ -1,5 +1,5 @@
 #!/bin/bash
-date -j -f "%a %b %d %T %Z %Y" "`date`" "+%s" >> /tmp/o3x.log
+date '+%s' >> /tmp/o3x.log
 echo $0 >> /tmp/o3x.log
 
 launchctl list | grep org.openzfsonosx.zconfigd 1>/dev/null

--- a/scripts/pkg-scripts/preinstall_actions/0uninstall
+++ b/scripts/pkg-scripts/preinstall_actions/0uninstall
@@ -1,6 +1,6 @@
 #!/bin/bash
 set +e
-date -j -f "%a %b %d %T %Z %Y" "`date`" "+%s" >> /tmp/o3x.log
+date '+%s' >> /tmp/o3x.log
 echo $0 >> /tmp/o3x.log
 pkgutil --pkgs | grep net.lundman.openzfs |\
 while read apkg

--- a/scripts/pkg-scripts/preinstall_actions/lookforzpool
+++ b/scripts/pkg-scripts/preinstall_actions/lookforzpool
@@ -1,5 +1,5 @@
 #!/bin/bash
-date -j -f "%a %b %d %T %Z %Y" "`date`" "+%s" >> /tmp/o3x.log
+date '+%s' >> /tmp/o3x.log
 echo $0 >> /tmp/o3x.log
 set -e
 

--- a/scripts/pkg-scripts/preinstall_actions/unloadzfs
+++ b/scripts/pkg-scripts/preinstall_actions/unloadzfs
@@ -1,5 +1,5 @@
 #!/bin/bash
-date -j -f "%a %b %d %T %Z %Y" "`date`" "+%s" >> /tmp/o3x.log
+date '+%s' >> /tmp/o3x.log
 echo $0 >> /tmp/o3x.log
 set -e
 


### PR DESCRIPTION
This PR fixes an issue where some pre-, post- and uninstall scripts output an error message on certain locales.

The affected command lines were prone to failure because they assumed `LC_ALL` and `LC_TIME` to be unset (or set to an US-American locale). To reproduce the issue, run:

```
$ bash -c 'export LC_ALL=; export LC_TIME=de_DE.UTF-8; date -j -f "%a %b %d %T %Z %Y" "`date`" "+%s"'
Failed conversion of ``Di 23 Okt 2018 07:54:11 CEST'' using format ``%a %b %d %T %Z %Y''
date: illegal time format
usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ... 
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
```

The reason why the original command uses that indirection is probably due to [miscommunication](https://stackoverflow.com/q/38348963).
