### PR TITLE
Fix os requirements

### DIFF
--- a/resources/English.lproj/Welcome.rtf
+++ b/resources/English.lproj/Welcome.rtf
@@ -30,12 +30,12 @@ You will be guided through the steps necessary to install
 \b\fs24 \cf5 System Requirements:
 \b0\fs26 \
 
-\i\fs22 Mac OS X operating system:
+\i\fs22 Operating system:
 \i0 \
 
-\b Mojave
+\b macOS Mojave
 \b0  (v10.14) down to 
-\b Mountain Lion
+\b OS X Mountain Lion
 \b0  (v10.8)
 \i \
 2 GB of memory

--- a/resources/English.lproj/Welcome.rtf
+++ b/resources/English.lproj/Welcome.rtf
@@ -33,8 +33,8 @@ You will be guided through the steps necessary to install
 \i\fs22 Mac OS X operating system:
 \i0 \
 
-\b High Sierra
-\b0  (v10.13) down to 
+\b Mojave
+\b0  (v10.14) down to 
 \b Mountain Lion
 \b0  (v10.8)
 \i \


### PR DESCRIPTION
When updating my installation of OpenZFS on OS X, I stumbled over the installer not mentioning 10.14 in the OS requirements.

Please feel free to cherry pick the minimal change of just updating the name and number or the whole PR that uses "official" OS release names.